### PR TITLE
MudTable modification to support 2-way binding on CurrentPage (similar to RowsPerPage)

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TablePagerChangeCurrentPageTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TablePagerChangeCurrentPageTest.razor
@@ -1,0 +1,14 @@
+﻿@using System.ComponentModel
+@using System.Runtime.CompilerServices
+@namespace MudBlazor.UnitTests.TestComponents
+
+<MudTable Items="states" CurrentPage="@pagenum" RowsPerPage="10">
+    <RowTemplate>
+        <MudTd>@context</MudTd>
+    </RowTemplate> 
+    <PagerContent>
+        <MudTablePager />
+    </PagerContent>
+</MudTable>
+
+<MudButton Disabled="false" OnClick="@(() => TogglePage())" Variant="Variant.Outlined">Toggle Page</MudButton>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TablePagerChangeCurrentPageTest.razor.cs
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TablePagerChangeCurrentPageTest.razor.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.AspNetCore.Components;
+
+namespace MudBlazor.UnitTests.TestComponents
+{
+    public partial class TablePagerChangeCurrentPageTest : ComponentBase
+    {
+        public static string __description__ = "Table - Change CurrentPage Parameter From Code";
+        private const int page0 = 0;
+        private const int page1 = 1;
+        private int pagenum = page0;
+
+        private void TogglePage()
+        {
+            pagenum = (pagenum == page0) ? page1 : page0;
+            StateHasChanged();
+        }
+
+        private string[] states = { "Alabama", "Alaska", "American Samoa", "Arizona", "Arkansas", "California", "Colorado", "Connecticut", "Delaware", "District of Columbia", "Federated States of Micronesia", "Florida", "Georgia", "Guam", "Hawaii", "Idaho", "Illinois", "Indiana", "Iowa", "Kansas", "Kentucky", "Louisiana", "Maine", "Marshall Islands", "Maryland", "Massachusetts", "Michigan", "Minnesota", "Mississippi", "Missouri", "Montana", "Nebraska", "Nevada", "New Hampshire", "New Jersey", "New Mexico", "New York", "North Carolina", "North Dakota", "Northern Mariana Islands", "Ohio", "Oklahoma", "Oregon", "Palau", "Pennsylvania", "Puerto Rico", "Rhode Island", "South Carolina", "South Dakota", "Tennessee", "Texas", "Utah", "Vermont", "Virgin Island", "Virginia", "Washington", "West Virginia", "Wisconsin", "Wyoming", };
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableRowsPerPageTwoWayBindingTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableRowsPerPageTwoWayBindingTest.razor
@@ -10,6 +10,7 @@
               Dense="true" Hover="true"
               FixedHeader="true"
               SortLabel="Sort By"
+              @bind-CurrentPage=@CurrentPage
               @bind-RowsPerPage=@RowsPerPage>
         <RowTemplate>
             <MudTd DataLabel="Text">@context.Text</MudTd>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableRowsPerPageTwoWayBindingTest.razor.cs
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableRowsPerPageTwoWayBindingTest.razor.cs
@@ -17,6 +17,7 @@ namespace MudBlazor.UnitTests.TestComponents
         public static string __description__ = "Test Two-Way Binding of RowsPerPage Parameter.";
 
         private int _RowsPerPage = 3;
+        private int _CurrentPage = 1;
 
         [Parameter]
         public int RowsPerPage
@@ -31,8 +32,25 @@ namespace MudBlazor.UnitTests.TestComponents
             }
         }
 
+
+        [Parameter]
+        public int CurrentPage
+        {
+            get => _CurrentPage;
+            set
+            {
+                if (_CurrentPage == value)
+                    return;
+                _CurrentPage = value;
+                CurrentPageChanged.InvokeAsync(value);
+            }
+        }
+
         [Parameter]
         public EventCallback<int> RowsPerPageChanged { get; set; }
+
+        [Parameter]
+        public EventCallback<int> CurrentPageChanged { get; set; }
 
 
         private ViewModel viewModel = new ViewModel();

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableRowsPerPageTwoWayBindingTest.razor.cs
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableRowsPerPageTwoWayBindingTest.razor.cs
@@ -2,10 +2,8 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
@@ -51,7 +49,6 @@ namespace MudBlazor.UnitTests.TestComponents
 
         [Parameter]
         public EventCallback<int> CurrentPageChanged { get; set; }
-
 
         private ViewModel viewModel = new ViewModel();
 

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -1921,6 +1921,35 @@ namespace MudBlazor.UnitTests.Components
             comp.WaitForAssertion(() => rowsPerPage.Should().Be(newRowsPerPage, "ValueChanged EventCallback fired correctly"));
         }
 
+
+        /// <summary>
+        /// Tests checks that RowsPerPage Parameter is two-way bindable
+        /// </summary>
+        [Test]
+        public async Task CurrentPageParameterTwoWayBinding()
+        {
+            int currentPage = 1;
+            int newCurrentPage = 2;
+            var comp = Context.RenderComponent<TableRowsPerPageTwoWayBindingTest>(parameters => parameters
+                .Add(p => p.RowsPerPage, currentPage)
+                .Add(p => p.CurrentPageChanged, (s) =>
+                {
+                    currentPage = int.Parse(s.ToString());
+                })
+            );
+            //Check the component rendered correctly with the initial CurrentPage
+            var t = comp.Find("input.mud-select-input").GetAttribute("Value");
+            int.Parse(t).Should().Be(currentPage, "The component rendered correctly");
+            //open the menu
+            var menuItem = comp.Find("div.mud-input-control");
+            menuItem.Click();
+
+            //Now select the 2 and check it
+            var items = comp.FindAll("div.mud-list-item").ToArray();
+            items[1].Click();
+            comp.WaitForAssertion(() => currentPage.Should().Be(newCurrentPage, "ValueChanged EventCallback fired correctly"));
+        }
+
         /// <summary>
         /// Tests that clicking a row in a non-editable table does not set IsEditing to true and stop the table from updating.
         /// </summary>

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -1921,33 +1921,33 @@ namespace MudBlazor.UnitTests.Components
             comp.WaitForAssertion(() => rowsPerPage.Should().Be(newRowsPerPage, "ValueChanged EventCallback fired correctly"));
         }
 
-
         /// <summary>
         /// Tests checks that RowsPerPage Parameter is two-way bindable
         /// </summary>
         [Test]
         public async Task CurrentPageParameterTwoWayBinding()
         {
-            int currentPage = 1;
-            int newCurrentPage = 2;
-            var comp = Context.RenderComponent<TableRowsPerPageTwoWayBindingTest>(parameters => parameters
-                .Add(p => p.RowsPerPage, currentPage)
+            int currentPage = 0;
+
+            var testComponent = Context.RenderComponent<TableRowsPerPageTwoWayBindingTest>(parameters => parameters
+                .Add(p => p.CurrentPage, 0)
+                .Add(p => p.RowsPerPage, 10)
                 .Add(p => p.CurrentPageChanged, (s) =>
                 {
                     currentPage = int.Parse(s.ToString());
                 })
             );
-            //Check the component rendered correctly with the initial CurrentPage
-            var t = comp.Find("input.mud-select-input").GetAttribute("Value");
-            int.Parse(t).Should().Be(currentPage, "The component rendered correctly");
-            //open the menu
-            var menuItem = comp.Find("div.mud-input-control");
-            menuItem.Click();
 
-            //Now select the 2 and check it
-            var items = comp.FindAll("div.mud-list-item").ToArray();
-            items[1].Click();
-            comp.WaitForAssertion(() => currentPage.Should().Be(newCurrentPage, "ValueChanged EventCallback fired correctly"));
+            var table = testComponent.Instance;
+            testComponent.WaitForAssertion(() => table.CurrentPage.Should().Be(0));
+
+            await testComponent.InvokeAsync(() => table.CurrentPage = 1);
+            testComponent.WaitForAssertion(() => table.CurrentPage.Should().Be(1));
+            currentPage.Should().Be(1);
+
+            await testComponent.InvokeAsync(() => table.CurrentPage = 0);
+            testComponent.WaitForAssertion(() => table.CurrentPage.Should().Be(0));
+            currentPage.Should().Be(0);
         }
 
         /// <summary>
@@ -1993,6 +1993,21 @@ namespace MudBlazor.UnitTests.Components
             //Toggle the rows per page value from 10 back to  to 35
             buttonComponent.Find("button").Click();
             testComponent.WaitForAssertion(() => table.RowsPerPage.Should().Be(35));
+        }
+
+        [Test]
+        public async Task CurrentPageChangeValueFromCode()
+        {
+            var testComponent = Context.RenderComponent<TablePagerChangeCurrentPageTest>();
+            var table = testComponent.FindComponent<MudTable<string>>().Instance;
+            var buttonComponent = testComponent.FindComponent<MudButton>();
+            testComponent.WaitForAssertion(() => table.CurrentPage.Should().Be(0));
+            //Toggle the current page value from 0 to 1
+            buttonComponent.Find("button").Click();
+            testComponent.WaitForAssertion(() => table.CurrentPage.Should().Be(1));
+            //Toggle the current page value from 1 back to 0
+            buttonComponent.Find("button").Click();
+            testComponent.WaitForAssertion(() => table.CurrentPage.Should().Be(0));
         }
 
         /// <summary>

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -1769,7 +1769,8 @@ namespace MudBlazor.UnitTests.Components
             tr.Length.Should().Be(39); // 01 Table header + 14 Group Headers + 14 Group Footers + 10 Entries
 
             // Navigating to page 2
-            table.NavigateTo(1);
+            comp.WaitForAssertion(() => table.NavigateTo(1));
+            comp.WaitForAssertion(() => table.CurrentPage.Should().Be(1));
 
             // Page 02:
             // [00] Aston Martin

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -169,7 +169,6 @@ namespace MudBlazor
         /// Current Page two-way bindable parameter
         /// </summary>
         [Parameter] public EventCallback<int> CurrentPageChanged { get; set; }
-        
 
         /// <summary>
         /// The page index of the currently displayed page (Zero based). Usually called by MudTablePager.

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -166,6 +166,12 @@ namespace MudBlazor
         [Parameter] public EventCallback<int> RowsPerPageChanged { get; set; }
 
         /// <summary>
+        /// Current Page two-way bindable parameter
+        /// </summary>
+        [Parameter] public EventCallback<int> CurrentPageChanged { get; set; }
+        
+
+        /// <summary>
         /// The page index of the currently displayed page (Zero based). Usually called by MudTablePager.
         /// Note: requires a MudTablePager in PagerContent.
         /// </summary>
@@ -176,12 +182,8 @@ namespace MudBlazor
             get => _currentPage;
             set
             {
-                if (_currentPage == value)
-                    return;
-                _currentPage = value;
-                InvokeAsync(StateHasChanged);
-                if (_isFirstRendered)
-                    InvokeServerLoadFunc();
+                if (_currentPage != value)
+                    SetCurrentPage(value);
             }
         }
 
@@ -499,6 +501,17 @@ namespace MudBlazor
         public void NavigateTo(int pageIndex)
         {
             CurrentPage = Math.Min(Math.Max(0, pageIndex), NumPages - 1);
+        }
+
+        public void SetCurrentPage(int page)
+        {
+            if (_currentPage == page)
+                return;
+            _currentPage = page;
+            StateHasChanged();
+            CurrentPageChanged.InvokeAsync(_currentPage);
+            if (_isFirstRendered)
+                InvokeServerLoadFunc();
         }
 
         public void SetRowsPerPage(int size)


### PR DESCRIPTION

## Description
MudTable modification to support 2-way binding on CurrentPage (similar to RowsPerPage). This allows client code to capture and for instance save the last page when a user returns. it is restore 

This is a feature request and not related to any known issues. 

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
Rreplace the MudBlazor Nuget w/ this project and the source generator to verify functionality in an existing app.

Added a unit test public async Task CurrentPageParameterTwoWayBinding().

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
